### PR TITLE
Remove mention of example with wrong url

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Using the above is recommended, but as per [NuGet's plugin discovery rules](http
 
 [Linux or Mac helper script](helpers/installcredprovider.sh)
 
-Examples:
-- `wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash`
-- `sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"`
-
 > Note: this script only installs the netcore version of the plugin. If you need to have it working with mono msbuild, you will need to download the version with both netcore and netfx binaries following the steps in [Manual installation on Linux and Mac](#installation-on-linux-and-mac)
 
 #### Manual installation on Linux and Mac


### PR DESCRIPTION
This poorly placed comment is causing people to download Windows binaries on macOS.